### PR TITLE
Update context7 ENTRYPOINT

### DIFF
--- a/images/context7/Dockerfile
+++ b/images/context7/Dockerfile
@@ -6,4 +6,4 @@ RUN npm install @upstash/context7-mcp
 FROM gcr.io/distroless/nodejs24-debian12
 COPY --from=build /app /app
 WORKDIR /app
-CMD ["node_modules/.bin/context7-mcp"]
+ENTRYPOINT ["/nodejs/bin/node", "node_modules/@upstash/context7-mcp/dist/index.js"]

--- a/images/context7/README.md
+++ b/images/context7/README.md
@@ -1,9 +1,10 @@
 Context7 MCP Server
 ===================
 
-[GitHub / Docs](https://github.com/upstash/context7)
+[GitHub / Docs](https://github.com/upstash/context7)\
+[npm](https://www.npmjs.com/package/@upstash/context7-mcp)
 
-I was not able to find a container provided by context7.
+I was not able to find an official container for context7.
 
 Claude
 ------
@@ -18,11 +19,10 @@ Claude
         "run",
         "-i",
         "--rm",
-        "ghcr.io/bendwyer/mcp-images:context7"
-      ],
-      "headers": {
-        "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY:-''}"
-      }
+        "ghcr.io/bendwyer/mcp-images/context7:1",
+        "--api-key",
+        "${CONTEXT7_API_KEY:-''}"
+      ]
     }
   }
 }


### PR DESCRIPTION
This PR adjustes the context7 ENTRYPOINT command to account for running in a distroless container. Permits the passing of command line flags to the container.