### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,6 @@
 version: 2
 updates:
   - package-ecosystem: docker
-    directory: /images
+    directories: /images/**
     schedule:
       interval: weekly


### PR DESCRIPTION
This PR switches from `directory:` to `directories:` in order for dependabot to...dependably...retrieve updates for Dockerfiles.